### PR TITLE
Add simple ChatGPT-style Next.js chat app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# AI-chatbots
+# AI Chatbots
+
+Simple ChatGPT-style chat interface built with Next.js. It includes a sidebar for selecting chats, a scrollable message area, and a fixed input box.
+
+## Development
+
+- `npm install` to install dependencies
+- `npm run dev` to start the development server
+- `npm test` to run tests (none configured)

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { message } = await req.json();
+  const reply = `AI: You said "${message}"`;
+  return NextResponse.json({ reply });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,8 @@
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: sans-serif;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import './globals.css';
+
+export const metadata = {
+  title: 'AI Chat',
+  description: 'Simple ChatGPT-like interface'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, height: '100vh' }}>{children}</body>
+    </html>
+  );
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,0 +1,83 @@
+.app {
+  display: flex;
+  height: 100%;
+}
+
+.sidebar {
+  width: 260px;
+  background: #202123;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.newChat {
+  background: #343541;
+  border: none;
+  color: #fff;
+  padding: 1rem;
+  cursor: pointer;
+}
+
+.chatList {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.chatItem {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+}
+
+.chatItem:hover,
+.chatItem.active {
+  background: #343541;
+}
+
+.chatWindow {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #343541;
+  color: #fff;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.userMessage,
+.assistantMessage {
+  margin-bottom: 1rem;
+  max-width: 80%;
+  line-height: 1.4;
+}
+
+.userMessage {
+  text-align: right;
+}
+
+.inputArea {
+  display: flex;
+  padding: 1rem;
+  background: #40414f;
+}
+
+.input {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+  border-radius: 4px;
+}
+
+.send {
+  margin-left: 0.5rem;
+  padding: 0 1rem;
+  background: #10a37f;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { useState, useEffect, useRef, FormEvent } from 'react';
+import styles from './page.module.css';
+
+type Message = { role: 'user' | 'assistant'; content: string };
+type Chat = { id: number; title: string; messages: Message[] };
+
+export default function Home() {
+  const [chats, setChats] = useState<Chat[]>([]);
+  const [currentId, setCurrentId] = useState<number | null>(null);
+  const [input, setInput] = useState('');
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('chats');
+    if (saved) {
+      const parsed: Chat[] = JSON.parse(saved);
+      setChats(parsed);
+      if (parsed.length > 0) setCurrentId(parsed[0].id);
+    } else {
+      const initial: Chat = { id: Date.now(), title: 'New Chat', messages: [] };
+      setChats([initial]);
+      setCurrentId(initial.id);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('chats', JSON.stringify(chats));
+  }, [chats]);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [chats, currentId]);
+
+  const currentChat = chats.find(c => c.id === currentId);
+
+  const newChat = () => {
+    const chat: Chat = { id: Date.now(), title: 'New Chat', messages: [] };
+    setChats(prev => [chat, ...prev]);
+    setCurrentId(chat.id);
+  };
+
+  const sendMessage = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || !currentChat) return;
+
+    const userMsg: Message = { role: 'user', content: input };
+    const updated: Chat = {
+      ...currentChat,
+      title: currentChat.messages.length === 0 ? input.slice(0, 20) : currentChat.title,
+      messages: [...currentChat.messages, userMsg]
+    };
+    setChats(prev => prev.map(c => (c.id === currentId ? updated : c)));
+    setInput('');
+
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: input })
+      });
+      const data = await res.json();
+      const botMsg: Message = { role: 'assistant', content: data.reply };
+      setChats(prev => prev.map(c => (c.id === currentId ? { ...updated, messages: [...updated.messages, botMsg] } : c)));
+    } catch {
+      const botMsg: Message = { role: 'assistant', content: 'Error getting response.' };
+      setChats(prev => prev.map(c => (c.id === currentId ? { ...updated, messages: [...updated.messages, botMsg] } : c)));
+    }
+  };
+
+  return (
+    <div className={styles.app}>
+      <aside className={styles.sidebar}>
+        <button className={styles.newChat} onClick={newChat}>+ New Chat</button>
+        <div className={styles.chatList}>
+          {chats.map(chat => (
+            <div
+              key={chat.id}
+              className={`${styles.chatItem} ${chat.id === currentId ? styles.active : ''}`}
+              onClick={() => setCurrentId(chat.id)}
+            >
+              {chat.title}
+            </div>
+          ))}
+        </div>
+      </aside>
+      <main className={styles.chatWindow}>
+        <div className={styles.messages}>
+          {currentChat?.messages.map((m, i) => (
+            <div key={i} className={m.role === 'user' ? styles.userMessage : styles.assistantMessage}>
+              {m.content}
+            </div>
+          ))}
+          <div ref={endRef} />
+        </div>
+        <form className={styles.inputArea} onSubmit={sendMessage}>
+          <input
+            className={styles.input}
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            placeholder="Type your message..."
+          />
+          <button className={styles.send} type="submit">Send</button>
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ai-chatbots",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.15",
+    "@types/node": "20.11.30"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a basic Next.js app with TypeScript
- implement ChatGPT-like chat UI with sidebar and persistent chats
- add simple API route that echoes user messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1cf34a2fc832eb0cb6fc94931927a